### PR TITLE
add hspec test-suite (and a test for sizeChange)

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,1 @@
+:set -itest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
 # The different configurations we want to test. You could also do things like
 # change flags or use --stack-yaml to point to a different file.
 env:
-- ARGS="--resolver lts-2 --stack-yaml stack-lts-2.yaml"
-- ARGS="--resolver lts-3 --stack-yaml stack-lts-3.yaml"
+- ARGS="--stack-yaml stack-lts-2.yaml"
+- ARGS="--stack-yaml stack-lts-3.yaml"
 - ARGS="--resolver nightly"
 
 before_install:
@@ -26,7 +26,7 @@ before_install:
 # This line does all of the work: installs GHC if necessary, build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
-script: stack $ARGS --no-terminal --install-ghc test patches-vector:test-patches-vector --haddock
+script: stack $ARGS --no-terminal --install-ghc test patches-vector:doctest-patches-vector patches-vector:spec-patches-vector --haddock
 
 # Caching so the next build will be fast too.
 cache:

--- a/doctest.hs
+++ b/doctest.hs
@@ -1,0 +1,4 @@
+import Test.DocTest
+
+main :: IO ()
+main = doctest ["Data/Patch/Internal.hs", "-i", "test", "-i."]

--- a/patches-vector.cabal
+++ b/patches-vector.cabal
@@ -35,9 +35,9 @@ library
                      , microlens >= 0.2 && < 0.4
   default-language:    Haskell2010
 
-test-suite             test-patches-vector
+test-suite             doctest-patches-vector
   type: exitcode-stdio-1.0
-  main-is: tests.hs
+  main-is: doctest.hs
   build-depends: base >= 4.7 && < 4.9, QuickCheck >= 2.7 && < 2.9, patches-vector, doctest >= 0.9 && < 0.11
   default-language:    Haskell2010
 
@@ -46,3 +46,12 @@ test-suite             benchmarks-patches-vector
   main-is: benchmarks.hs
   hs-source-dirs: bm
   build-depends: base >= 4.7 && < 4.9, QuickCheck >= 2.7 && < 2.9, patches-vector, criterion >= 1.1 && < 1.2, vector >= 0.10 && <0.12
+
+test-suite             spec-patches-vector
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs: test
+  other-modules:       Data.Patch.InternalSpec
+                     , Test.Util
+                     , Test.UtilSpec
+  build-depends: base >= 4.7 && < 4.9, QuickCheck >= 2.7 && < 2.9, patches-vector, criterion >= 1.1 && < 1.2, vector >= 0.10 && <0.12, hspec >= 2.1 && < 2.3

--- a/stack-lts-2.yaml
+++ b/stack-lts-2.yaml
@@ -8,9 +8,10 @@ packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: 
+extra-deps:
 - edit-distance-vector-1.0.0.2
 - microlens-0.3.4.1
+- doctest-0.10.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/Data/Patch/InternalSpec.hs
+++ b/test/Data/Patch/InternalSpec.hs
@@ -1,0 +1,16 @@
+
+module Data.Patch.InternalSpec where
+
+import           Data.Monoid
+import           Test.Hspec
+import           Test.QuickCheck
+
+import           Data.Patch.Internal
+import           Test.Util ()
+
+spec :: Spec
+spec = do
+  describe "applicable" $ do
+    it "mempty is always applicable" $ do
+      property $ \d ->
+        applicable (mempty :: Patch Int) d

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -1,0 +1,40 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Util where
+
+import           Control.Applicative
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import           Test.QuickCheck
+
+import           Data.Patch
+
+nonEmpty :: Vector a -> Bool
+nonEmpty = (>0) . Vector.length
+
+editsTo :: Arbitrary a => Vector a -> Gen (Edit a)
+editsTo v = do
+  i <- choose (0, Vector.length v -1)
+  c <- elements [const (Insert i), \o _ -> Delete i o, Replace i]
+  x <- arbitrary
+  return $ c (v Vector.! i) x
+
+patchesFrom' :: (Eq a, Arbitrary a) => Vector a -> Gen (Patch a)
+patchesFrom' v | Vector.length v > 0 = fromList <$> listOf (editsTo v)
+patchesFrom' _ | otherwise           = fromList <$> listOf (Insert 0 <$> arbitrary)
+
+patchesFrom :: Vector Int -> Gen (Patch Int)
+patchesFrom = patchesFrom'
+
+divergingPatchesFrom :: Vector Int -> Gen (Patch Int, Patch Int)
+divergingPatchesFrom v = (,) <$> patchesFrom v <*> patchesFrom v
+
+historyFrom :: Vector Int -> Int -> Gen [Patch Int]
+historyFrom _ 0 = return []
+historyFrom d m = do
+  p <- patchesFrom d
+  r <- historyFrom (apply p d) $ m - 1
+  return (p:r)
+
+instance Arbitrary a => Arbitrary (Vector a) where
+  arbitrary = Vector.fromList <$> listOf arbitrary

--- a/test/Test/UtilSpec.hs
+++ b/test/Test/UtilSpec.hs
@@ -1,0 +1,39 @@
+
+module Test.UtilSpec where
+
+import           Data.Monoid
+import           Test.Hspec
+import           Test.QuickCheck
+
+import           Data.Patch.Internal
+import           Test.Util
+
+spec :: Spec
+spec = do
+  describe "patchesFrom" $ do
+    it "creates applicable patches" $ do
+      property $ \d ->
+        forAll (patchesFrom d) $ \p -> applicable p d
+
+    it "creates patches that are right-composable with mempty" $ do
+      property $ \d ->
+        forAll (patchesFrom d) $ \p -> composable mempty p
+
+    it "creates patches that are left-composable with mempty" $ do
+      property $ \d ->
+        forAll (patchesFrom d) $ \p -> composable p mempty
+
+  describe "historyFrom" $ do
+    it "creates patches that are applicable in sequence" $ do
+      property $ \d ->
+        forAll (historyFrom d 2) $ \[p, q] ->
+          applicable p d && applicable q (apply p d)
+
+    it "creates patches that are applicable in merged form" $ do
+      property $ \d ->
+        forAll (historyFrom d 2) $ \[p, q] ->
+          applicable (p <> q) d
+
+    it "creates patches that are composable" $ do
+      property $ \d ->
+        forAll (historyFrom d 2) $ \[p, q] -> composable p q

--- a/tests.hs
+++ b/tests.hs
@@ -1,4 +1,0 @@
-import Test.DocTest
-
-main :: IO ()
-main = doctest ["Data/Patch/Internal.hs"]


### PR DESCRIPTION
This is more a janitorial change to get more test infrastructure in place. The added test-case (for `sizeChange`) is not very substantial.

@liamoc: Personally I would move more tests from doctest to hspec, but I wanted to get your opinion first. For example the tests for `applicable` and `composable` seem more like tests for `patchesFrom` and `historyFrom` than documentation. I would move them into `Data.Patch.InternalSpec`.
