### PR TITLE
Compatibility with LTS-12.4

### DIFF
--- a/patches-vector.cabal
+++ b/patches-vector.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                patches-vector
-version:             0.1.5.4
+version:             0.1.6
 synopsis:            Patches (diffs) on vectors: composable, mergeable, and invertible.
 description:         A patch is a collection of modifications (edits) to be made to a sequence of elements. Commonly
                      found in version control systems, patches are also a simple example of a groupoid, supporting (partial) composition
@@ -33,7 +33,7 @@ library
                      , Data.Patch.Internal
   build-depends:       base >=4.7 && <5
                      , edit-distance-vector >=1.0 && <1.1
-                     , vector >= 0.10 && < 0.12
+                     , vector >= 0.10 && < 0.13
                      , microlens >= 0.2 && < 0.5
   default-language:    Haskell2010
 
@@ -41,9 +41,9 @@ test-suite             doctest-patches-vector
   type: exitcode-stdio-1.0
   main-is: doctest.hs
   build-depends:       base >= 4.7 && < 5
-                     , QuickCheck >= 2.7 && < 2.9
+                     , QuickCheck >= 2.7 && < 2.12
                      , patches-vector
-                     , doctest >= 0.9 && < 0.12
+                     , doctest >= 0.9 && < 0.17
   default-language:    Haskell2010
 
 test-suite             benchmarks-patches-vector
@@ -51,10 +51,10 @@ test-suite             benchmarks-patches-vector
   main-is: benchmarks.hs
   hs-source-dirs: bm
   build-depends:       base >= 4.7 && < 5
-                     , QuickCheck >= 2.7 && < 2.9
+                     , QuickCheck >= 2.7 && < 2.12
                      , patches-vector
-                     , criterion >= 1.1 && < 1.2
-                     , vector >= 0.10 && <0.12
+                     , criterion >= 1.1 && < 1.45
+                     , vector >= 0.10 && <0.13
   default-language:    Haskell2010
 
 test-suite             spec-patches-vector
@@ -65,9 +65,9 @@ test-suite             spec-patches-vector
                      , Test.Util
                      , Test.UtilSpec
   build-depends:       base >= 4.7 && < 5 
-                     , QuickCheck >= 2.7 && < 2.9
+                     , QuickCheck >= 2.7 && < 2.12
                      , patches-vector
-                     , criterion >= 1.1 && < 1.2
-                     , vector >= 0.10 && <0.12
-                     , hspec >= 2.1 && < 2.3
+                     , criterion >= 1.1 && < 1.5
+                     , vector >= 0.10 && <0.13
+                     , hspec >= 2.1 && < 2.6
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,32 +1,7 @@
-# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+resolver: lts-12.4
 
-# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-7.10
-
-# Local packages, usually specified by relative directory name
 packages:
 - '.'
 
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
 - edit-distance-vector-1.0.0.4
-# Override default flag values for local packages and extra-deps
-flags: {}
-
-# Extra package databases containing global packages
-extra-package-dbs: []
-
-# Control whether we use the GHC we find on the path
-# system-ghc: true
-
-# Require a specific version of stack, using version ranges
-# require-stack-version: -any # Default
-# require-stack-version: >= 0.1.4.0
-
-# Override the architecture used by stack, especially useful on Windows
-# arch: i386
-# arch: x86_64
-
-# Extra directories used by stack for building
-# extra-include-dirs: [/path/to/dir]
-# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
Probably doesn't work on GHC<8.0 because you need to add `semigroups` as a dependency and I haven't done that.